### PR TITLE
fix: 修复 CI 工作流 - Dockerfile Go 版本和 setup-node 缓存问题

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
 
       - name: Install frontend dependencies
         working-directory: web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ permissions:
   contents: write
   packages: write
   pull-requests: write
-  # BuildKit type=gha 缓存走 Actions Cache API；write 含读权限；不显式授权时 actions 为 none
   actions: write
 
 jobs:
@@ -57,14 +56,12 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.0"
+          go-version-file: go.mod
           cache: true
 
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: web/package-lock.json
 
       - name: 安装前端依赖
         working-directory: web
@@ -157,7 +154,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # 优先用 GHCR 专用缓存镜像（release 之间可复用）；ignore-error 避免首次无 buildcache 时拉取失败
           cache-from: |
             type=registry,ref=${{ steps.ghcr.outputs.image }}:buildcache,ignore-error=true
             type=gha,scope=codex-proxy-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 阶段一：构建
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates nodejs npm
 


### PR DESCRIPTION
## 修复内容

**问题 1: Docker 构建失败**
- 错误: `go.mod requires go >= 1.26 (running go 1.25.13)`
- 原因: Dockerfile 使用 `golang:1.25-alpine`，但 go.mod 已升级到 go 1.26
- 修复: `golang:1.25-alpine` → `golang:1.26-alpine`

**问题 2: 所有构建 job 的 setup-node 缓存步骤失败**
- 错误: `Some specified paths were not resolved, unable to cache dependencies.`
- 原因: `actions/setup-node@v7` 的 `cache: npm` 配置导致缓存路径解析失败，步骤被标记为 failure，后续所有步骤被跳过
- 修复: 移除 `cache: npm` 和 `cache-dependency-path` 配置（pr-test-build.yml 和 release.yml）

**问题 3: release.yml 中 setup-go 版本硬编码**
- 修复: `go-version: "1.25.0"` → `go-version-file: go.mod`，自动匹配 go.mod 中的版本

## 影响范围
- `Dockerfile`
- `.github/workflows/pr-test-build.yml`
- `.github/workflows/release.yml`